### PR TITLE
Cargo subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 tests/example_projects/rust_basic_bin/target
 tests/example_projects/rust_basic_lib/target
+tests/example_projects/rust_invalid/target

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Watch patterns are the file patterns that lightmon will watch for file changes, 
 
 ### Rust
 ```
-lightmon rust [cargo_subcommand]?
+lightmon rust [cargo_subcommand]? [cargo_subcommand_args]?
 ```
 
 ##### Watch Patterns
@@ -37,15 +37,15 @@ lightmon rust [cargo_subcommand]?
 ##### Exec Commands
 By default, the `rust` configuration will set the Exec command to `cargo run` if it's a binary project, and `cargo test` if it's a library.
 
-However, you can override this behavior by specifying the subcommand manually. For example, you want to do `cargo test` on a binary project instead of `cargo run` on file change events, you should do the following:
+However, you can override this behavior by specifying any valid cargo subcommand (and any arguments). For example, if you wanted to run `cargo build --bin my_bin --all-targets`, you can run the following:
 ```
-lightmon rust test
+lightmon rust build --bin my_bin --all-targets
 ```
 
 Refer to `lightmon help rust` for more information.
 
 ### Node.js
-**Note: This configuration also works for React, React-Native, TypeScript, etc. Anything with a package.json!**
+_Note: This configuration also works for React, React-Native, TypeScript, etc. i.e.: anything with a package.json!_
 
 ```
 lightmon node

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,27 +54,37 @@ impl Cli {
         let config: Option<Cli> = match matches.subcommand() {
             ("rust", Some(sub_matcher)) => Some(Self::build_rust_config(Some(sub_matcher))),
             ("node", Some(_)) => Some(Self::build_node_config()),
-            ("python", Some(_)) => None,
             ("shell", Some(sub_matcher)) => Some(Self::build_shell_config(sub_matcher)),
             _ => {
+                // Note, since we are using AppSettings::AllowExternalSubcommands, we need to check
+                // again that a subcommand was passed in. This is because an unsupported lang would
+                // still match to this branch.
+                if matches.subcommand_name().is_some() {
+                    error!(
+                        "{} is not supported. Consider using `lightmon shell` instead.",
+                        matches.subcommand_name().unwrap()
+                    );
+                    None
+                }
                 //automatic lang detection
-                // if Path::new("lightmon.toml").exists(){
-                //     //TODO
-                // } else if Path::new("nodemon.json").exists() {
-                //TODO
-                // }
-                if Path::new("package.json").exists() {
+                else if Path::new("lightmon.toml").exists() {
+                    //TODO
+                    None
+                } else if Path::new("nodemon.json").exists() {
+                    //TODO
+                    None
+                } else if Path::new("package.json").exists() {
                     Some(Self::build_node_config())
                 } else if Path::new("Cargo.toml").exists() {
                     Some(Self::build_rust_config(None))
                 } else {
+                    error!("Unable to resolve configuration automatically. Consider using `lightmon shell` instead.");
                     None
                 }
             }
         };
 
         if config.is_none() {
-            error!("Argument configuration not yet supported!");
             std::process::exit(1);
         }
         config.unwrap()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,14 +65,14 @@ impl Cli {
                         matches.subcommand_name().unwrap()
                     );
                     None
-                }
+
                 //automatic lang detection
-                else if Path::new("lightmon.toml").exists() {
-                    //TODO
-                    None
-                } else if Path::new("nodemon.json").exists() {
-                    //TODO
-                    None
+                //else if Path::new("lightmon.toml").exists() {
+                //    //TODO
+                //    None
+                //} else if Path::new("nodemon.json").exists() {
+                //    //TODO
+                //    None
                 } else if Path::new("package.json").exists() {
                     Some(Self::build_node_config())
                 } else if Path::new("Cargo.toml").exists() {

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -9,20 +9,7 @@ args:
       help: Use verbose output
 subcommands:
   - rust:
-      about: "Use rust preset for lightmon. Lightmon will detect the type of rust project you are working in automatically."
-      subcommands:
-        - build:
-            about: Use `cargo build` for exec command when file changes are detected
-        - test:
-            about: Use `cargo test` for exec command when file changes are detected
-        - doc:
-            about: Use `cargo doc` for exec command when file changes are detected
-        - clippy:
-            about: Use `cargo clippy` for exec command when file changes are detected
-        - bench:
-            about: Use `cargo bench` for exec command when file changes are detected
-        - check:
-            about: Use `cargo check` for exec command when file changes are detected
+      about: "Use rust preset for lightmon. Lightmon will detect the type of rust project you are working in automatically.\n Note: if you want to use a custom cargo command, you can provide the subcommand and any arguments and the exec command will get resolved accordingly."
   - node:
       about: Use node preset for lightmon. `lightmon node help` for more info
   - shell:

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -13,7 +13,7 @@ subcommands:
   - node:
       about: Use node preset for lightmon. `lightmon node help` for more info
   - shell:
-      about: Use a custom shell script for unsupported languages. `lightmon shell help` for more info
+      about: Use a custom shell script for unsupported languages or complicated configurations. 
       args:
         - script:
             short: s

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -9,7 +9,7 @@ args:
       help: Use verbose output
 subcommands:
   - rust:
-      about: Use rust preset for lightmon. `lightmon rust help` for more info
+      about: "Use rust preset for lightmon. Lightmon will detect the type of rust project you are working in automatically."
       subcommands:
         - build:
             about: Use `cargo build` for exec command when file changes are detected

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -9,11 +9,24 @@ args:
       help: Use verbose output
 subcommands:
   - rust:
-      about: Use rust preset for lightmon
+      about: Use rust preset for lightmon. `lightmon rust help` for more info
+      subcommands:
+        - build:
+            about: Use `cargo build` for exec command when file changes are detected
+        - test:
+            about: Use `cargo test` for exec command when file changes are detected
+        - doc:
+            about: Use `cargo doc` for exec command when file changes are detected
+        - clippy:
+            about: Use `cargo clippy` for exec command when file changes are detected
+        - bench:
+            about: Use `cargo bench` for exec command when file changes are detected
+        - check:
+            about: Use `cargo check` for exec command when file changes are detected
   - node:
-      about: Ues node preset for lightmon
+      about: Use node preset for lightmon. `lightmon node help` for more info
   - shell:
-      about: Use a custom shell script for unsupported languages
+      about: Use a custom shell script for unsupported languages. `lightmon shell help` for more info
       args:
         - script:
             short: s

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -12,15 +12,6 @@ subcommands:
       about: Use rust preset for lightmon
   - node:
       about: Ues node preset for lightmon
-  - python:
-      about: Use python preset for lightmon
-      args:
-        - entry:
-            short: e
-            long: entry_file
-            value_name: entry
-            help: Entry file to run on file changes
-            required: true
   - shell:
       about: Use a custom shell script for unsupported languages
       args:

--- a/tests/example_projects/rust_invalid/Cargo.toml
+++ b/tests/example_projects/rust_invalid/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_invalid"
+version = "0.1.0"
+authors = ["Reagan McFarland <reagan.mcfarland1059@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/lightmon.rs
+++ b/tests/lightmon.rs
@@ -22,6 +22,7 @@ fn verbose_shows_debug_statements() -> Result<(), Box<dyn std::error::Error>> {
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
         Some(vec!["-v", "shell", "-s", "script.sh", "-w", ".sh"]),
+        None,
     )
     .unwrap();
     assert!(output.stderr.contains("DEBUG lightmon::cli]"));

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -36,6 +36,7 @@ fn node_basic_script_start_resolution() -> Result<(), Box<dyn std::error::Error>
         EP_NODE_BASIC_SCRIPT_START_PATH,
         Duration::from_secs(10),
         None,
+        None,
     )
     .unwrap();
     assert_eq!(output.stdout, BASIC_START_SCRIPT_RESOLUTION_EXPECTED);
@@ -50,6 +51,7 @@ fn node_basic_main_resolution() -> Result<(), Box<dyn std::error::Error>> {
         EP_NODE_BASIC_MAIN_ENTRY_POINT_PATH,
         Duration::from_secs(10),
         None,
+        None,
     )
     .unwrap();
     assert_eq!(output.stdout, BASIC_MAIN_RESOLUTION_EXPECTED);
@@ -60,7 +62,13 @@ fn node_basic_main_resolution() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 #[serial(node)]
 fn node_basic_fallback_resolution() -> Result<(), Box<dyn std::error::Error>> {
-    let output = run_example(EP_NODE_BASIC_FALLBACK_PATH, Duration::from_secs(10), None).unwrap();
+    let output = run_example(
+        EP_NODE_BASIC_FALLBACK_PATH,
+        Duration::from_secs(10),
+        None,
+        None,
+    )
+    .unwrap();
     assert_eq!(output.stdout, BASIC_FALLBACK_RESOLUTION_EXPECTED);
     Ok(())
 }

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -23,7 +23,7 @@ Hello, World!
 #[serial(rust)]
 fn rust_basic_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn child lightmon process at rust directory
-    let output = run_example(EP_RUST_BASIC_BIN_PATH, Duration::from_secs(5), None).unwrap();
+    let output = run_example(EP_RUST_BASIC_BIN_PATH, Duration::from_secs(5), None, None).unwrap();
     assert_eq!(output.stdout, BASIC_BIN_CONFIGURATION_EXPECTED);
     Ok(())
 }
@@ -32,7 +32,7 @@ fn rust_basic_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
 #[serial(rust)]
 fn rust_basic_lib_configuration() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn child lightmon process at rust directory
-    let output = run_example(EP_RUST_BASIC_LIB_PATH, Duration::from_secs(5), None).unwrap();
+    let output = run_example(EP_RUST_BASIC_LIB_PATH, Duration::from_secs(5), None, None).unwrap();
     assert!(output.stdout.contains("tests::it_works"));
     Ok(())
 }
@@ -41,7 +41,13 @@ fn rust_basic_lib_configuration() -> Result<(), Box<dyn std::error::Error>> {
 #[serial(rust)]
 fn rust_invalid_configuration_errors_out() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn child lightmon process at rust directory
-    let output = run_example(EP_RUST_INVALID_PATH, Duration::from_secs(5), None).unwrap();
+    let output = run_example(
+        EP_RUST_INVALID_PATH,
+        Duration::from_secs(5),
+        None,
+        Some(true),
+    )
+    .unwrap();
     assert!(output
         .stderr
         .contains("ERROR lightmon::cli] Could not find which type of rust project this is."));
@@ -57,9 +63,10 @@ fn rust_subcommand_override_in_bin_configuration() -> Result<(), Box<dyn std::er
         EP_RUST_BASIC_BIN_PATH,
         Duration::from_secs(5),
         Some(vec!["rust", "doc"]),
+        None,
     )
     .unwrap();
-    assert!(output.stderr.contains("Documenting rust_bin"));
+    assert!(!output.stdout.contains("Hello, World!"));
     Ok(())
 }
 

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -57,6 +57,22 @@ fn rust_invalid_configuration_errors_out() -> Result<(), Box<dyn std::error::Err
 
 #[test]
 #[serial(rust)]
+fn rust_subcommand_override_with_args() -> Result<(), Box<dyn std::error::Error>> {
+    // Spawn child lightmon process at rust directory
+    let output = run_example(
+        EP_RUST_BASIC_BIN_PATH,
+        Duration::from_secs(5),
+        Some(vec!["rust", "build", "--bin", "foo"]),
+        None,
+    )
+    .unwrap();
+    assert!(output.stderr.contains("no bin target named `foo`"));
+
+    Ok(())
+}
+
+#[test]
+#[serial(rust)]
 fn rust_subcommand_override_in_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn child lightmon process at rust directory
     let output = run_example(

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 use utils::*;
 
 const EP_RUST_BASIC_BIN_PATH: &str = "./tests/example_projects/rust_basic_bin";
+const EP_RUST_BASIC_LIB_PATH: &str = "./tests/example_projects/rust_basic_lib";
+const EP_RUST_INVALID_PATH: &str = "./tests/example_projects/rust_invalid";
 
 static BASIC_BIN_CONFIGURATION_EXPECTED: &str = "lightmon started (rust mode)
 Hello, World!
@@ -23,6 +25,41 @@ fn rust_basic_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn child lightmon process at rust directory
     let output = run_example(EP_RUST_BASIC_BIN_PATH, Duration::from_secs(5), None).unwrap();
     assert_eq!(output.stdout, BASIC_BIN_CONFIGURATION_EXPECTED);
+    Ok(())
+}
+
+#[test]
+#[serial(rust)]
+fn rust_basic_lib_configuration() -> Result<(), Box<dyn std::error::Error>> {
+    // Spawn child lightmon process at rust directory
+    let output = run_example(EP_RUST_BASIC_LIB_PATH, Duration::from_secs(5), None).unwrap();
+    assert!(output.stdout.contains("tests::it_works"));
+    Ok(())
+}
+
+#[test]
+#[serial(rust)]
+fn rust_invalid_configuration_errors_out() -> Result<(), Box<dyn std::error::Error>> {
+    // Spawn child lightmon process at rust directory
+    let output = run_example(EP_RUST_INVALID_PATH, Duration::from_secs(5), None).unwrap();
+    assert!(output
+        .stderr
+        .contains("ERROR lightmon::cli] Could not find which type of rust project this is."));
+    assert!(output.stdout.is_empty());
+    Ok(())
+}
+
+#[test]
+#[serial(rust)]
+fn rust_subcommand_override_in_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
+    // Spawn child lightmon process at rust directory
+    let output = run_example(
+        EP_RUST_BASIC_BIN_PATH,
+        Duration::from_secs(5),
+        Some(vec!["rust", "doc"]),
+    )
+    .unwrap();
+    assert!(output.stderr.contains("Documenting rust_bin"));
     Ok(())
 }
 

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -45,6 +45,7 @@ fn shell_basic_configuration() -> Result<(), Box<dyn std::error::Error>> {
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
         Some(vec!["shell", "-s", "script.sh", "-w", ".sh"]),
+        None,
     )
     .unwrap();
     assert_eq!(output.stdout, BASIC_CONFIGURATION_EXPECTED);
@@ -59,6 +60,7 @@ fn shell_should_error_with_no_script_path() -> Result<(), Box<dyn std::error::Er
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
         Some(vec!["shell", "-w", ".sh"]),
+        None,
     )
     .unwrap();
     assert_eq!(output.stderr, NO_SCRIPT_PATH_EXPECTED);
@@ -73,6 +75,7 @@ fn shell_should_error_with_no_watch_patterns() -> Result<(), Box<dyn std::error:
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
         Some(vec!["shell", "-s", "script.sh"]),
+        Some(true),
     )
     .unwrap();
     assert_eq!(output.stderr, NO_WATCH_PATTERNS_EXPECTED);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -21,6 +21,7 @@ pub fn run_example(
     project_path: &str,
     sleep_time: Duration,
     arg_list: Option<Vec<&str>>,
+    is_going_to_fail: Option<bool>,
 ) -> Result<CommandOutput, Box<dyn std::error::Error>> {
     // Spawn child lightmon process at node directory
     let mut cmd = Command::cargo_bin("lightmon").ok().unwrap();
@@ -39,10 +40,12 @@ pub fn run_example(
     std::thread::sleep(sleep_time);
 
     // Kill it
-    assert!(
-        child.kill().is_ok(),
-        "child process should be able to be killed"
-    );
+    if let None = is_going_to_fail {
+        assert!(
+            child.kill().is_ok(),
+            "child process should be able to be killed"
+        );
+    }
 
     // read stdout and stderr into strings
     let mut stdout = String::new();


### PR DESCRIPTION
Closes #19 

Implementation is much expressive than initially discussed in the issue.

`lightmon` will attempt to resolve the exec command to `cargo run` if `src/main.rs` is present, and `cargo test` if `src/lib.rs` is present.

However, you can specify the cargo sub command as well as pass any arguments very easily. For example, the following command will resolve the exec command as `cargo build --bin my_bin`:

```
lightmon rust build --bin my_bin
```