### PR TITLE
Arch User Repository Installation Method

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Reagan McFarland <me@reaganmcf.com>
+# Maintainer: Alay Shah <alay.shah@rutgers.edu>
+pkgname=lightmon
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="A lightweight, cross-platform, language-agnostic 'run code on file change' tool, inspired by Nodemon"
+license=('GPL3')
+arch=('x86_64')
+url="https://github.com/reaganmcf/lightmon"
+makedepends=('git' 'cargo')
+source=("git+https://github.com/reaganmcf/lightmon.git")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "$pkgname"
+}
+
+build() {
+  cd "$pkgname"
+  env CARGO_INCREMENTAL=0 cargo build --release --locked
+}
+
+package() {
+  cd "$pkgname"
+  install -D -m755 "target/release/lightmon" "$pkgdir/usr/bin/lightmon"
+}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ But, we also support other popular package managers if you would rather use them
 $ cargo install lightmon
 ```
 
+##### Arch AUR
+```bash
+$ yay -S lightmon
+```
+
 ## License
 `lightmon` uses the [GNU GPL v3.0](https://github.com/reaganmcf/lightmon/blob/master/LICENSE) License
 


### PR DESCRIPTION
Users can install `lightmon` using an AUR helper such as `yay`