### PR TITLE
fix: Kill previous exec process before spawning new exec process

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,10 +1,13 @@
 //! Contains the method for starting a thread that will run the exec commands in parallel.
 
-use std::io::{self};
 use std::process::Command;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::thread;
+use std::{
+    io::{self},
+    process::Child,
+};
 
 pub use crate::cli::Cli;
 pub use crate::LightmonEvent;
@@ -15,6 +18,7 @@ pub use crate::LightmonEvent;
 pub fn start(
     cli_args: Arc<Cli>,
     lightmon_event_sender: Sender<LightmonEvent>,
+    exec_child_process_sender: Sender<Child>,
 ) -> std::thread::JoinHandle<()> {
     thread::spawn(move || {
         debug!("thread started");
@@ -28,27 +32,27 @@ pub fn start(
                 cmd.arg(argument);
             }
             debug!("final cmd = {:?}", cmd);
-            let mut child = cmd.spawn().unwrap();
+            let child = cmd.spawn().unwrap();
+            debug!("child process pid = {:?}", child.id());
+            match exec_child_process_sender.send(child) {
+                Ok(_) => {}
+                Err(_) => {
+                    error!("Unable to send event to main loop. Something seriously went wrong!");
+                    std::process::exit(1);
+                }
+            }
             loop {
                 let mut input = String::new();
                 if let Ok(n) = io::stdin().read_line(&mut input) {
                     if input.eq("rs\n") {
                         debug!("rs RECEIEVED");
                         match lightmon_event_sender.send(LightmonEvent::KillAndRestartChild) {
-                            Ok(()) => {
-                                let child_killed = child.kill();
-                                match child_killed {
-                                    Ok(()) => {}
-                                    Err(e) => {
-                                        error!("program cannot be quit and restarted: {:?}", e);
-                                        std::process::exit(1);
-                                    }
-                                }
-                            }
+                            Ok(_) => {}
                             Err(_) => {
-                                panic!("failed to send initial lightmon event. Something went seriously wrong!");
+                                error!("Unable to kill and restart the process. Something seriously went wrong!");
+                                std::process::exit(1);
                             }
-                        };
+                        }
                     } else {
                         debug!("unknown input, bits read from input {:?}", n);
                         debug!("input = {:?}", input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,14 +101,16 @@ mod exec;
 mod watcher;
 
 use cli::Cli;
-use std::sync::mpsc::channel;
 use std::sync::Arc;
+use std::{
+    process::Child,
+    sync::mpsc::{channel, Receiver, Sender},
+};
 
 /// Type of events that lightmon handles.
 pub enum LightmonEvent {
     /// When lightmon first starts up successfully, it forces the exec thread to go off once
     InitExec,
-    KillChild,
     KillAndRestartChild,
 }
 
@@ -118,6 +120,10 @@ fn main() {
 
     // get ligthmon event channel
     let (lightmon_event_sender, lightmon_event_receiver) = channel();
+
+    // exec children references channel. Used to kill already running exec threads
+    let (exec_child_process_sender, exec_child_process_receiver): (Sender<Child>, Receiver<Child>) =
+        channel();
 
     // Send first dummy event
     match lightmon_event_sender.send(LightmonEvent::InitExec) {
@@ -137,14 +143,39 @@ fn main() {
             match lightmon_event {
                 LightmonEvent::KillAndRestartChild => {
                     debug!("KILL AND RESTART RECEIEVED");
-                    exec::start(cli_args.clone(), lightmon_event_sender.clone());
-                }
-                LightmonEvent::KillChild => {
-                    debug!("KILL RECEIEVED");
+
+                    // kill child
+                    if let Ok(mut exec_child) = exec_child_process_receiver.recv() {
+                        match exec_child.kill() {
+                            Ok(_) => debug!("Killed child process."),
+                            Err(e) => debug!("Failed to kill child process! {:?}", e),
+                        }
+
+                        // waiting after killing sounds weird because it is. But, the following is
+                        // from the rust doc:
+                        //
+                        // On some systems, calling wait or similar is necessary for the OS to release resources.
+                        // A process that terminated but has not been waited on is still around as a “zombie”.
+                        // Leaving too many zombies around may exhaust global resources (for example process IDs).
+                        // The standard library does not automatically wait on child processes (not even if the Child is dropped), it is up to the application developer to do so.
+                        // As a consequence, dropping Child handles without waiting on them first is not recommended in long-running applications.
+                        let _ = exec_child.try_wait();
+                    }
+
+                    // Restart
+                    exec::start(
+                        cli_args.clone(),
+                        lightmon_event_sender.clone(),
+                        exec_child_process_sender.clone(),
+                    );
                 }
                 LightmonEvent::InitExec => {
                     debug!("INIT EXEC RECEIVED");
-                    exec::start(cli_args.clone(), lightmon_event_sender.clone());
+                    exec::start(
+                        cli_args.clone(),
+                        lightmon_event_sender.clone(),
+                        exec_child_process_sender.clone(),
+                    );
                 }
             }
         }


### PR DESCRIPTION
Closes #20 

Before this fix, previous exec process would not be killed between
restarts (either from `rs` or file changes). This means the process' would pile up over time and that is
definitely not a good thing.

However, with this patch, the exec process sends the `Child` handle to the
main event loop through a new channel where they get dealt with before
the new exec process is spawned to take it's place.