### PR TITLE
Cleanup codebase and refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "lightmon"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.2.0-alpha.2"
 authors = ["Reagan McFarland <me@reaganmcf.com>", "Alay Shah"]
 description = "A lightweight, cross-platform, language-agnostic 'run code on file change' tool, inspired by Nodemon"
 homepage = "https://github.com/reaganmcf/lightmon"
-documentation = "https://docs.rs/lightmon"
 license = "GPL-3.0"
 categories = ["command-line-utilities"]
 keywords = ["dev-tools", "nodemon", "productivity", "file-monitoring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightmon"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.2"
 authors = ["Reagan McFarland <me@reaganmcf.com>", "Alay Shah"]
 description = "A lightweight, cross-platform, language-agnostic 'run code on file change' tool, inspired by Nodemon"
 homepage = "https://github.com/reaganmcf/lightmon"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,3 @@
-//! Responsible for parsing command line arguments and returning information needed by the
-//! watcher and exec threads.
-
-extern crate serde_json;
 use clap::{App, AppSettings, ArgMatches};
 use env_logger::Builder;
 use log::LevelFilter;
@@ -10,9 +6,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-/// Enum definitions of all supported languages
+// Enum definitions of all supported languages
 #[derive(Debug)]
-pub enum SupportedLanguage {
+pub(crate) enum SupportedLanguage {
     Rust,
     Node,
     Shell,
@@ -28,18 +24,18 @@ impl std::fmt::Display for SupportedLanguage {
     }
 }
 
-/// Struct that contains all parsed data necessary for `exec` and `watcher`
+// Struct that contains all parsed data necessary for `exec` and `watcher`
 #[derive(Debug)]
-pub struct Cli {
+pub(crate) struct Cli {
     pub watch_patterns: Vec<String>, // file patterns to watch
     pub project_language: SupportedLanguage,
     pub exec_commands: Vec<String>, // list of commands to run
 }
 
 impl Cli {
-    /// Entry point for generating a new Cli struct. Uses clap, as well as automatic language
-    /// project detection to determine which config to build.
-    pub fn new() -> Self {
+    // Entry point for generating a new Cli struct. Uses clap, as well as automatic language
+    // project detection to determine which config to build.
+    pub(crate) fn new() -> Self {
         let yaml = load_yaml!("cli.yaml");
         let matches: ArgMatches = App::from_yaml(yaml)
             .global_setting(AppSettings::AllowExternalSubcommands)
@@ -90,39 +86,16 @@ impl Cli {
         config.unwrap()
     }
 
-    /// Build the `nodejs` configuration.
-    ///
-    /// ### Watch Patterns
-    /// [`.jsx`, `.js`, `.html`, `.css`]
-    ///
-    /// ### Exec Commands
-    /// If there is a `package.json` in the root directory, lightmon attempts to resolve the exec command
-    /// in the following order:
-    ///  1. The value at `scripts.start`
-    ///  2. `node main` where `main` is the value of the `main` key in `package.json` (the entry point of the project).
-    ///
-    /// **NOTE:** exec command will fallback to `node index.js` if all of the above fail.
-    ///
-    /// For example, the following `package.json` will result in the exec command resolving to
-    /// `react-scripts start`:
-    /// ```json
-    /// {
-    ///     "name": "calculator",
-    ///     "main": "index.js",
-    ///     "scripts": {
-    ///         "start": "react-scripts start"
-    ///         "build": "react-scripts build"
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// In this example, the exec command will resolve to `node my_entry_point.js`:
-    /// ```json
-    /// {
-    ///     "name": "bar",
-    ///     "main": "my_entry_point.js"
-    /// }
-    /// ```
+    // Build the `nodejs` configuration.
+    //
+    // ### Watch Patterns
+    // [`.jsx`, `.js`, `.html`, `.css`]
+    //
+    // ### Exec Commands
+    // If there is a `package.json` in the root directory, lightmon attempts to resolve the exec command
+    // in the following order:
+    //  1. The value at `scripts.start`
+    //  2. `node main` where `main` is the value of the `main` key in `package.json` (the entry point of the project).
     fn build_node_config() -> Self {
         debug!("Configuring for node mode...");
         let watch_patterns: Vec<String> = vec![
@@ -177,22 +150,22 @@ impl Cli {
         }
     }
 
-    /// Build the `rust` configuration.
-    ///
-    /// ### Watch Patterns
-    /// [`Cargo.toml`, `.rs`]
-    ///
-    /// ### Exec Commands
-    /// If no subcommand is passed in, the exec command resolves with the following rules:
-    ///  1. `cargo run` if `src/main.rs` exists
-    ///  2. `cargo test` if `src/lib.rs` exists
-    ///
-    /// However, you can also specify any subcommand and custom arguments explicitly and they will
-    /// be carried over to the exec command. For example
-    /// ```
-    /// lightmon rust build --bin my_bin --all-targets
-    /// ```
-    /// Will resolve the exec command to `cargo build --bin my_bin --all-targets`
+    // Build the `rust` configuration.
+    //
+    // ### Watch Patterns
+    // [`Cargo.toml`, `.rs`]
+    //
+    // ### Exec Commands
+    // If no subcommand is passed in, the exec command resolves with the following rules:
+    //  1. `cargo run` if `src/main.rs` exists
+    //  2. `cargo test` if `src/lib.rs` exists
+    //
+    // However, you can also specify any subcommand and custom arguments explicitly and they will
+    // be carried over to the exec command. For example
+    // ```
+    // lightmon rust build --bin my_bin --all-targets
+    // ```
+    // Will resolve the exec command to `cargo build --bin my_bin --all-targets`
     fn build_rust_config(sub_matcher: Option<&ArgMatches>) -> Self {
         let mut exec_commands: Vec<String> = Vec::new();
         debug!("Configuring for rust mode...");
@@ -230,8 +203,8 @@ impl Cli {
         }
     }
 
-    /// Build the `shell` configuration.
-    /// The watch patterns and exec commands are determined by the arguments passed in.
+    // Build the `shell` configuration.
+    // The watch patterns and exec commands are determined by the arguments passed in.
     fn build_shell_config(sub_matcher: &ArgMatches) -> Self {
         let mut watch_patterns: Vec<String> = Vec::new();
         let mut exec_commands: Vec<String> = Vec::new();

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -1,5 +1,5 @@
 name: lightmon
-version: "0.0.1"
+version: "v0.2.0-alpha.2"
 author: Reagan McFarland <me@reaganmcf.com>, Alay Shah
 about: A light-weight, cross-platform, language agnostic \"run code on file change\" tool, inspired by Nodemon
 args:

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,21 +1,18 @@
-//! Contains the method for starting a thread that will run the exec commands in parallel.
+// Contains the method for starting a thread that will run the exec commands in parallel.
 
 use std::process::Command;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::thread;
-use std::{
-    io::{self},
-    process::Child,
-};
+use std::{io, process::Child};
 
-pub use crate::cli::Cli;
-pub use crate::LightmonEvent;
+use crate::cli::Cli;
+use crate::LightmonEvent;
 
-/// Start an exec thread that will run the exec commands
-///
-/// Returns a handler to the thread
-pub fn start(
+// Start an exec thread that will run the exec commands
+//
+// Returns a handler to the thread
+pub(crate) fn start(
     cli_args: Arc<Cli>,
     lightmon_event_sender: Sender<LightmonEvent>,
     exec_child_process_sender: Sender<Child>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,101 +1,8 @@
-//! <p align="center">
-//!   <img height="250px" src="https://raw.githubusercontent.com/reaganmcf/lightmon/master/assets/logo.png"/>
-//! </p>
-//!
-//! # lightmon
-//! A lightweight, cross-platform, language-agnostic "run code on file change" tool, inspired by Nodemon
-//! <p align="left">
-//!  <img src="https://img.shields.io/static/v1?label=status&message=In%20Development&color=critical"/>
-//!  <img src="https://img.shields.io/crates/v/lightmon"/>
-//!  <img src="https://github.com/reaganmcf/lightmon/actions/workflows/ci.yml/badge.svg"/>
-//!  <img src="https://shields.io/github/license/reaganmcf/lightmon"/>
-//! </p>
-//!
-//! ###  Why lightmon over nodemon?
-//! There are many reasons to use lightmon over nodemon: __it's faster, lighter, and can be used for all types of projects__. Not only this, but lightmon is a **drag and drop  replacement** for projects that use `nodemon` because lightman can parse existing `nodemon.json` config files.
-//! - Note: [Parse nodemon.json config is still WIP](https://github.com/reaganmcf/lightmon/issues/3)
-//!
-//! ## Usage
-//! ```
-//! lightmon
-//! ```
-//! By default, `lightmon` will automatically determine what kind of files it should watch based upon your project structure. For example, if a `node_modules` folder is present in the directory, `lightmon` will run in the `node` configuration, parsing your `package.json` to infer the correct command to run.
-//!
-//! ## Supported languages
-//!
-//! Watch patterns are the file patterns that lightmon will watch for file changes, and Exec commands are the list of commands that are executed when those events happen.
-//!
-//! ### Rust
-//! ```
-//! lightmon rust [cargo_subcommand]?
-//! ```
-//!
-//! ##### Watch Patterns
-//! [`Cargo.toml`, `.rs`]
-//!
-//! ##### Exec Commands
-//! By default, the `rust` configuration will set the Exec command to `cargo run` if it's a binary project, and `cargo test` if it's a library.
-//!
-//! However, you can override this behavior by specifying the subcommand manually. For example, you want to do `cargo test` on a binary project instead of `cargo run` on file change events, you should do the following:
-//! ```
-//! lightmon rust test
-//! ```
-//!
-//! Refer to `lightmon help rust` for more information.
-//! ### Node.js
-//! **Note: This configuration also works for React, React-Native, TypeScript, etc. Anything with a package.json!**
-//!
-//! ```
-//! lightmon node
-//! ```
-//!
-//! ##### Watch Patterns
-//!
-//! [`.jsx`, `.js`, `.css`, `.html`]
-//! ##### Exec Commands
-//!
-//! If there is a package.json in the root directory, lightmon attempts to resolve the exec command in the following order:
-//!
-//! - The value at `scripts.start`
-//! - `node main` where main is the value of the main key in package.json (the entry point of the project).
-//!
-//! **NOTE:** The Exec command will fallback to `node index.js` if all of the above fail.
-//!
-//! For example, the following package.json will result in the Exec command resolving to `react-scripts start`:
-//! ```json
-//! {
-//!     "name": "calculator",
-//!     "main": "index.js",
-//!     "scripts": {
-//!         "start": "react-scripts start",
-//!         "build": "react-scripts build"
-//!     }
-//! }
-//! ```
-//!
-//! ### C/C++
-//! It's very tricky to infer what the patterns and exec commands could be, so we recommend using `shell` mode with a custom script (see below).
-//!
-//! ### Shell (for unsupported languages or complicated builds)
-//! `lightmon shell -s <path> -w <patterns>`
-//! Here users can specify the path to the shell script and which file types to watch for seperated by commas.
-//!
-//! For example, let's say you have a python project with a file named `start.py` at the root of the project. Whenever you edit any `.py` files in the project, you want to
-//! re-run `python start.py`. To accomplish this, you could create a simple script called `run.sh` with the following contents:
-//! ```sh
-//! python start.py
-//! ```
-//!
-//! Now, you just run the following:
-//! ```
-//! lightmon shell -s run.sh -w .py,.ipynb
-//! ```
-
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate clap;
-extern crate notify;
+
 mod cli;
 mod exec;
 mod watcher;
@@ -107,14 +14,12 @@ use std::{
     sync::mpsc::{channel, Receiver, Sender},
 };
 
-/// Type of events that lightmon handles.
-pub enum LightmonEvent {
-    /// When lightmon first starts up successfully, it forces the exec thread to go off once
+pub(crate) enum LightmonEvent {
     InitExec,
     KillAndRestartChild,
 }
 
-/// Entry point for the entire binary.
+// Entry point for the entire binary.
 fn main() {
     let cli_args = Arc::new(Cli::new());
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,9 +1,3 @@
-//! Contains the thread that will start the file watcher and send LightmonEvents back to the main
-//! thread when they happen.
-
-extern crate notify;
-extern crate walkdir;
-
 use notify::poll::PollWatcher;
 use notify::{RecursiveMode, Watcher};
 use std::collections::HashSet;
@@ -16,13 +10,15 @@ use std::{
 };
 use walkdir::WalkDir;
 
-pub use crate::cli::Cli;
-pub use crate::LightmonEvent;
+use crate::cli::Cli;
+use crate::LightmonEvent;
 
-/// Start a new watcher thread that will send LightmonEvents back to the main thread.
-///
-/// Returns a handle to the new thread
-pub fn start(cli_args: Arc<Cli>, lightmon_event_sender: Sender<LightmonEvent>) -> JoinHandle<()> {
+// Start a new watcher thread that will send LightmonEvents back to the main thread.
+// Returns a handle to the new thread
+pub(crate) fn start(
+    cli_args: Arc<Cli>,
+    lightmon_event_sender: Sender<LightmonEvent>,
+) -> JoinHandle<()> {
     std::thread::spawn(move || {
         let (tx, rx) = channel();
         let mut watcher = PollWatcher::with_delay_ms(tx, 100).unwrap();
@@ -78,7 +74,7 @@ pub fn start(cli_args: Arc<Cli>, lightmon_event_sender: Sender<LightmonEvent>) -
                     }
                 }
                 Err(e) => {
-                    error!("Failed to receieve event from channel {:?}", e);
+                    error!("Failed to receive event from channel {:?}", e);
                 }
             }
         }

--- a/tests/lightmon.rs
+++ b/tests/lightmon.rs
@@ -1,5 +1,5 @@
-extern crate assert_cmd;
 mod utils;
+
 use assert_cmd::prelude::*;
 use std::process::Command;
 use std::time::Duration;
@@ -8,7 +8,7 @@ use utils::*;
 const EP_SHELL_BASIC_PATH: &str = "./tests/example_projects/shell_basic";
 
 #[test]
-fn unsupported_configuration_fails() -> Result<(), Box<dyn std::error::Error>> {
+fn unsupported_configuration_fails() -> TestResult {
     let mut cmd = Command::cargo_bin("lightmon")?;
     cmd.arg("java").assert().failure();
 
@@ -16,7 +16,7 @@ fn unsupported_configuration_fails() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn verbose_shows_debug_statements() -> Result<(), Box<dyn std::error::Error>> {
+fn verbose_shows_debug_statements() -> TestResult {
     // Spawn child lightmon process at
     let output = run_example(
         EP_SHELL_BASIC_PATH,

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,7 +1,7 @@
-mod utils;
-
 #[macro_use]
 extern crate serial_test;
+
+mod utils;
 use std::time::Duration;
 use utils::*;
 
@@ -31,7 +31,7 @@ called by script.start
 // node configuration where script.start is in package.json
 #[test]
 #[serial(node)]
-fn node_basic_script_start_resolution() -> Result<(), Box<dyn std::error::Error>> {
+fn node_basic_script_start_resolution() -> TestResult {
     let output = run_example(
         EP_NODE_BASIC_SCRIPT_START_PATH,
         Duration::from_secs(10),
@@ -46,7 +46,7 @@ fn node_basic_script_start_resolution() -> Result<(), Box<dyn std::error::Error>
 // node configuration where main is in package.json
 #[test]
 #[serial(node)]
-fn node_basic_main_resolution() -> Result<(), Box<dyn std::error::Error>> {
+fn node_basic_main_resolution() -> TestResult {
     let output = run_example(
         EP_NODE_BASIC_MAIN_ENTRY_POINT_PATH,
         Duration::from_secs(10),
@@ -61,7 +61,7 @@ fn node_basic_main_resolution() -> Result<(), Box<dyn std::error::Error>> {
 // node configuration where nothing can be resolved
 #[test]
 #[serial(node)]
-fn node_basic_fallback_resolution() -> Result<(), Box<dyn std::error::Error>> {
+fn node_basic_fallback_resolution() -> TestResult {
     let output = run_example(
         EP_NODE_BASIC_FALLBACK_PATH,
         Duration::from_secs(10),
@@ -75,7 +75,7 @@ fn node_basic_fallback_resolution() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[serial(node)]
-fn node_test_with_js_file_edits() -> Result<(), Box<dyn std::error::Error>> {
+fn node_test_with_js_file_edits() -> TestResult {
     let output = run_example_with_file_change(
         EP_NODE_BASIC_SCRIPT_START_PATH,
         Duration::from_secs(10),
@@ -89,7 +89,7 @@ fn node_test_with_js_file_edits() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[serial(node)]
-fn node_test_with_jsx_file_edits() -> Result<(), Box<dyn std::error::Error>> {
+fn node_test_with_jsx_file_edits() -> TestResult {
     let output = run_example_with_file_change(
         EP_NODE_BASIC_SCRIPT_START_PATH,
         Duration::from_secs(10),
@@ -103,7 +103,7 @@ fn node_test_with_jsx_file_edits() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[serial(node)]
-fn node_test_with_css_file_edits() -> Result<(), Box<dyn std::error::Error>> {
+fn node_test_with_css_file_edits() -> TestResult {
     let output = run_example_with_file_change(
         EP_NODE_BASIC_SCRIPT_START_PATH,
         Duration::from_secs(10),
@@ -117,7 +117,7 @@ fn node_test_with_css_file_edits() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[serial(node)]
-fn node_test_with_html_file_edits() -> Result<(), Box<dyn std::error::Error>> {
+fn node_test_with_html_file_edits() -> TestResult {
     let output = run_example_with_file_change(
         EP_NODE_BASIC_SCRIPT_START_PATH,
         Duration::from_secs(10),

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -21,7 +21,7 @@ Hello, World!
 
 #[test]
 #[serial(rust)]
-fn rust_basic_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
+fn rust_basic_bin_configuration() -> TestResult {
     // Spawn child lightmon process at rust directory
     let output = run_example(EP_RUST_BASIC_BIN_PATH, Duration::from_secs(5), None, None).unwrap();
     assert_eq!(output.stdout, BASIC_BIN_CONFIGURATION_EXPECTED);
@@ -30,7 +30,7 @@ fn rust_basic_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[serial(rust)]
-fn rust_basic_lib_configuration() -> Result<(), Box<dyn std::error::Error>> {
+fn rust_basic_lib_configuration() -> TestResult {
     // Spawn child lightmon process at rust directory
     let output = run_example(EP_RUST_BASIC_LIB_PATH, Duration::from_secs(5), None, None).unwrap();
     assert!(output.stdout.contains("tests::it_works"));
@@ -39,7 +39,7 @@ fn rust_basic_lib_configuration() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[serial(rust)]
-fn rust_invalid_configuration_errors_out() -> Result<(), Box<dyn std::error::Error>> {
+fn rust_invalid_configuration_errors_out() -> TestResult {
     // Spawn child lightmon process at rust directory
     let output = run_example(
         EP_RUST_INVALID_PATH,
@@ -57,7 +57,7 @@ fn rust_invalid_configuration_errors_out() -> Result<(), Box<dyn std::error::Err
 
 #[test]
 #[serial(rust)]
-fn rust_subcommand_override_with_args() -> Result<(), Box<dyn std::error::Error>> {
+fn rust_subcommand_override_with_args() -> TestResult {
     // Spawn child lightmon process at rust directory
     let output = run_example(
         EP_RUST_BASIC_BIN_PATH,
@@ -73,7 +73,7 @@ fn rust_subcommand_override_with_args() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 #[serial(rust)]
-fn rust_subcommand_override_in_bin_configuration() -> Result<(), Box<dyn std::error::Error>> {
+fn rust_subcommand_override_in_bin_configuration() -> TestResult {
     // Spawn child lightmon process at rust directory
     let output = run_example(
         EP_RUST_BASIC_BIN_PATH,
@@ -88,7 +88,7 @@ fn rust_subcommand_override_in_bin_configuration() -> Result<(), Box<dyn std::er
 
 #[test]
 #[serial(rust)]
-fn rust_basic_bin_test_with_rs_file_edits() -> Result<(), Box<dyn std::error::Error>> {
+fn rust_basic_bin_test_with_rs_file_edits() -> TestResult {
     let output = run_example_with_file_change(
         EP_RUST_BASIC_BIN_PATH,
         Duration::from_secs(10),

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -1,8 +1,7 @@
-mod utils;
-
 #[macro_use]
 extern crate serial_test;
-extern crate assert_cmd;
+
+mod utils;
 use std::time::Duration;
 use utils::*;
 
@@ -40,7 +39,7 @@ Hello, World!
 #[cfg(not(target_os = "windows"))]
 #[test]
 #[serial(shell)]
-fn shell_basic_configuration() -> Result<(), Box<dyn std::error::Error>> {
+fn shell_basic_configuration() -> TestResult {
     let output = run_example(
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
@@ -55,7 +54,7 @@ fn shell_basic_configuration() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(not(target_os = "windows"))]
 #[test]
 #[serial(shell)]
-fn shell_should_error_with_no_script_path() -> Result<(), Box<dyn std::error::Error>> {
+fn shell_should_error_with_no_script_path() -> TestResult {
     let output = run_example(
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
@@ -70,7 +69,7 @@ fn shell_should_error_with_no_script_path() -> Result<(), Box<dyn std::error::Er
 #[cfg(not(target_os = "windows"))]
 #[test]
 #[serial(shell)]
-fn shell_should_error_with_no_watch_patterns() -> Result<(), Box<dyn std::error::Error>> {
+fn shell_should_error_with_no_watch_patterns() -> TestResult {
     let output = run_example(
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),
@@ -85,7 +84,7 @@ fn shell_should_error_with_no_watch_patterns() -> Result<(), Box<dyn std::error:
 #[cfg(not(target_os = "windows"))]
 #[test]
 #[serial(shell)]
-fn shell_basic_with_file_changes() -> Result<(), Box<dyn std::error::Error>> {
+fn shell_basic_with_file_changes() -> TestResult {
     let output = run_example_with_file_change(
         EP_SHELL_BASIC_PATH,
         Duration::from_secs(5),

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,12 +1,13 @@
 #![allow(dead_code)]
 
-extern crate assert_cmd;
 use assert_cmd::prelude::*;
 use std::fs::OpenOptions;
 use std::io::{prelude::*, Read};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
+
+pub type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 pub struct CommandOutput {
     pub stdout: String,


### PR DESCRIPTION
This PR is sort of a kitchen sink patch, accomplishing the following:

1. Bump release cycle in Cargo to `v0.2.0-alpha.2`
2. Remove/trim a lot of the docstrings because we don't even get a `docs.rs` page since we are a binary
     - This isn't to say these comments weren't helpful, but they were a little too much so trimming them makes the code base tremendously more readable.  
3. Refactor and cleanup throughout the project
     - Unnecessary `extern crate`
     - Typedef long type definitions
     - and more